### PR TITLE
Mark f003.fasta as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.1]
+- List FASTA/f003.fasta as invalid, since it has comments with the invalid hash
+  sign instead of semicolon.
+
+## [1.3.0]
+- Add PAF/good3.paf
+- Fix error in PAF/good2.paf
+
 ## [1.2.0]
 - Add PAF format
 - Remove Pkg dependency in favor of TOML

--- a/FASTA/index.toml
+++ b/FASTA/index.toml
@@ -40,7 +40,7 @@ filename = "f002.fasta"
 origin = "BioPython"
 tags = ["dna", "multi"]
 
-[[valid]]
+[[invalid]]
 filename = "f003.fasta"
 origin = "BioPython"
 tags = ["dna", "multi", "comments"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FormatSpecimens"
 uuid = "3372ea36-2a1a-11e9-3eb7-996970b6ffbd"
 authors = ["Ben J. Ward <benjward@protonmail.com"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"


### PR DESCRIPTION
This file has comments beginning with #, which is not supported in FASTA. The original format had comments beginning with semicolons, but this is not supported by most parsers.